### PR TITLE
Try to add some code to generate the Grouping type info when we exporting the JSON string.

### DIFF
--- a/src/main/java/org/helm/notation2/parser/notation/grouping/GroupingAmbiguity.java
+++ b/src/main/java/org/helm/notation2/parser/notation/grouping/GroupingAmbiguity.java
@@ -33,7 +33,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
  *
  * @author hecht
  */
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "classType")
 public abstract class GroupingAmbiguity {
 
   protected List<GroupingElement> elements = new ArrayList<GroupingElement>();

--- a/src/main/java/org/helm/notation2/parser/notation/grouping/GroupingAmbiguity.java
+++ b/src/main/java/org/helm/notation2/parser/notation/grouping/GroupingAmbiguity.java
@@ -26,11 +26,14 @@ package org.helm.notation2.parser.notation.grouping;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
 /**
  * GroupingAmbiguity represents a single group in the grouping section
  *
  * @author hecht
  */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 public abstract class GroupingAmbiguity {
 
   protected List<GroupingElement> elements = new ArrayList<GroupingElement>();

--- a/src/main/java/org/helm/notation2/parser/notation/polymer/MonomerNotation.java
+++ b/src/main/java/org/helm/notation2/parser/notation/polymer/MonomerNotation.java
@@ -26,6 +26,7 @@ package org.helm.notation2.parser.notation.polymer;
 import org.helm.notation2.parser.exceptionparser.HELM1ConverterException;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 /**
  * MonomerNotation
@@ -33,6 +34,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
  *
  * @author shecht
  */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "classType")
 public abstract class MonomerNotation {
   protected String unit;
 

--- a/src/main/java/org/helm/notation2/parser/notation/polymer/MonomerNotationGroup.java
+++ b/src/main/java/org/helm/notation2/parser/notation/polymer/MonomerNotationGroup.java
@@ -33,14 +33,12 @@ import org.helm.notation2.parser.notation.ValidationMethod;
 import org.jdom2.JDOMException;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 /**
  * MonomerNotationGroup
  *
  * @author hecht
  */
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 public abstract class MonomerNotationGroup extends MonomerNotation {
 
   public List<MonomerNotationGroupElement> elements = new ArrayList<MonomerNotationGroupElement>();

--- a/src/main/java/org/helm/notation2/parser/notation/polymer/MonomerNotationGroup.java
+++ b/src/main/java/org/helm/notation2/parser/notation/polymer/MonomerNotationGroup.java
@@ -33,12 +33,14 @@ import org.helm.notation2.parser.notation.ValidationMethod;
 import org.jdom2.JDOMException;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 /**
  * MonomerNotationGroup
  *
  * @author hecht
  */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 public abstract class MonomerNotationGroup extends MonomerNotation {
 
   public List<MonomerNotationGroupElement> elements = new ArrayList<MonomerNotationGroupElement>();


### PR DESCRIPTION
Hi Sir,

I meet an issue when I try to use the exported JSON string of the Notation, we cannot distinguish the grouping type (mixture or or) in exported JSON string. 
This pull request will add a JsonTypeInfo attribute To the Grouping Class. It will cause the Jackson generate the Type info of the Grouping type ( Mixture or Or) to he exported JSON string.

Peace and Long Life,
Boris